### PR TITLE
Enviar el id de los clientes. También, mejor el query de clientes

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -100,10 +100,8 @@ async def agregar_trabajo(
 # Endpoint para obtener clientes
 @app.get("/clients/")
 async def get_clients(db: Session = Depends(get_db)):
-    # anterior mente se me duplicaban los clientes en el frontend
-    #ahora uso distint() para que no se dupliquen
-    client_names = db.query(Client.name).distinct().all()
-    return [{"name": c[0]} for c in client_names]
+    client_names = db.query(Client).all()
+    return [{"name": c.name, "id": c.id} for c in client_names]
 
 
 


### PR DESCRIPTION
Esto hace que el endpoint `/clients/` regrese los clientes con sus id, para que no haya error en el frontend (issue #7 ).

Estaba leyendo un poco sobre SQLAlchemy, y parece que estamos usando la API que ha sido reemplazada por otra: https://docs.sqlalchemy.org/en/20/orm/queryguide/query.html