### PR TITLE
fix: agregando POSTGRES_DB para que el nombre de la base sea eso por defecto

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
     environment:
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_NAME}
     volumes:
       - postgres:/var/lib/postgresql/data
     # dentro del mismo pod, se usa la puerta del contenedor para conectar


### PR DESCRIPTION
Esto es para que docker/podman cree la base de datos cuando cree el servidor de postgres. el `.env` ya tiene el valor `POSTGRES_DB` definido.